### PR TITLE
Default to entire play with optional filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
   const viewer      = document.getElementById("viewer");
   const parser      = new DOMParser();
   let   currentDoc  = null;
+  let   castHtml    = "";
 
   /* ----------- populate play list ------------- */
   plays.forEach(f=>{
@@ -157,6 +158,10 @@
   function populateActs(xml){
     actPicker.innerHTML = "";
     const acts = xml.querySelectorAll('body div[type="act"]');
+    const all = document.createElement("option");
+    all.value = "all";
+    all.textContent = "All Acts";
+    actPicker.appendChild(all);
     acts.forEach((act,i)=>{
       const o = document.createElement("option");
       const head = act.querySelector("head");
@@ -164,13 +169,22 @@
       o.textContent = head?head.textContent.trim():`Act ${i+1}`;
       actPicker.appendChild(o);
     });
-    actPicker.onchange = ()=>{populateScenes(acts[actPicker.value]); displayScene();};
-    populateScenes(acts[0]);
+    actPicker.onchange = ()=>{
+      const val = actPicker.value === "all" ? null : acts[actPicker.value];
+      populateScenes(val);
+      displayScene();
+    };
+    actPicker.value = "all";
+    populateScenes(null);
   }
 
   function populateScenes(act){
     scenePicker.innerHTML = "";
     const scenes = act?act.querySelectorAll('div[type="scene"]'):[];
+    const all = document.createElement("option");
+    all.value = "all";
+    all.textContent = "All Scenes";
+    scenePicker.appendChild(all);
     scenes.forEach((sc,i)=>{
       const o = document.createElement("option");
       const head = sc.querySelector("head");
@@ -179,20 +193,28 @@
       scenePicker.appendChild(o);
     });
     scenePicker.onchange = displayScene;
+    scenePicker.value = "all";
   }
 
   /* --------------- render view ---------------- */
   function displayScene(){
     if(!currentDoc) return;
     const acts = currentDoc.querySelectorAll('body div[type="act"]');
-    const act  = acts[actPicker.value] || acts[0];
-    const scenes = act.querySelectorAll('div[type="scene"]');
-    const scene  = scenes[scenePicker.value] || scenes[0];
+    let html = "";
+    if(actPicker.value === "all"){
+      acts.forEach(a=>{html += teiToHtml(a);});
+    }else{
+      const act  = acts[actPicker.value];
+      if(scenePicker.value === "all"){
+        html += teiToHtml(act);
+      }else{
+        const scenes = act.querySelectorAll('div[type="scene"]');
+        const scene  = scenes[scenePicker.value];
+        html += teiToHtml(scene);
+      }
+    }
 
-    viewer.innerHTML = "";                      // reset
-    const castList = currentDoc.querySelector("castList");
-    if(castList) viewer.innerHTML += teiToHtml(castList);
-    viewer.innerHTML += teiToHtml(scene);
+    viewer.innerHTML = castHtml + html;
   }
 
   /* --------------- main load ------------------ */
@@ -201,6 +223,8 @@
     try{
       const xml = await fetch(`XML/${file}`).then(r=>r.text());
       currentDoc = parser.parseFromString(xml,"application/xml");
+      const castList = currentDoc.querySelector("castList");
+      castHtml = castList ? teiToHtml(castList) : "";
       populateActs(currentDoc);
       displayScene();
     }catch(e){


### PR DESCRIPTION
## Summary
- allow filtering by adding "All Acts" and "All Scenes" options
- render dramatis personae once at the top
- show whole play by default

## Testing
- `node -e "fs=require('fs');const m=fs.readFileSync('index.html','utf8');const js=m.match(/<script>([\s\S]*)<\/script>/)[1];new Function(js);console.log('ok');"`