### PR TITLE
Fix cast formatting and speaker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
   <style>
     body{
-      font-family:Georgia,serif;
+      font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
       line-height:1.5;
       margin:1rem;
       max-width:45rem;
@@ -20,6 +20,10 @@
     #viewer{white-space:pre-wrap}
     .speech{position:relative;}
     .copy-btn{margin-left:.5rem;font-size:.8rem;}
+    #cast h3{
+      font-size:1rem;
+      margin:0;
+    }
   </style>
 </head>
 <body>
@@ -122,7 +126,12 @@
     let out = "";
     node.childNodes.forEach(ch=>{
       if(ch.nodeType === Node.TEXT_NODE){
-        out += ch.nodeValue.trim();
+        const text = ch.nodeValue;
+        if(text.trim()){
+          if(/^\s/.test(text)) out += ' ';
+          out += text.trim();
+          if(/\s$/.test(text)) out += ' ';
+        }
       }else{
         switch(ch.nodeName){
           case "w":
@@ -142,7 +151,7 @@
             out += teiToHtml(ch)+"<br><br>";
             break;
           case "speaker":
-            out += "<strong>"+teiToHtml(ch)+"</strong> ";
+            out += "<strong>"+teiToHtml(ch)+"</strong><br>";
             break;
           case "stage":
             out += "<em>"+teiToHtml(ch)+"</em><br>";
@@ -159,7 +168,11 @@
             break;
           }
           case "head":
-            out += "<h3>"+teiToHtml(ch)+"</h3>";
+            if(ch.parentNode && ch.parentNode.nodeName === "castGroup"){
+              out += "<li><strong>"+teiToHtml(ch)+"</strong></li>";
+            }else{
+              out += "<h3>"+teiToHtml(ch)+"</h3>";
+            }
             break;
           case "sp":
             out += '<p class="speech"><span class="speech-text">'+teiToHtml(ch)+'</span>'+
@@ -227,10 +240,10 @@
     }else{
       const act  = acts[actPicker.value];
       if(scenePicker.value === "all"){
-        showCast = actPicker.value === "0";
+        showCast = actPicker.value === "0"; /* show once for Act 1 when all scenes */
         html += teiToHtml(act);
       }else{
-        showCast = actPicker.value === "0";
+        showCast = actPicker.value === "0" && scenePicker.value === "0";
         const scenes = act.querySelectorAll('div[type="scene"]');
         const scene  = scenes[scenePicker.value];
         html += teiToHtml(scene);


### PR DESCRIPTION
## Summary
- keep consistent sans-serif font across the page
- ensure cast roles keep spaces when `<name>` is used
- put a line break after each speaker name
- only display the cast at Act 1 Scene 1

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ad081980083318eec07d21b6f8bdd