### PR TITLE
Fix spacing between words

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -79,8 +79,9 @@
     let out = "";
     node.childNodes.forEach(ch=>{
       if(ch.nodeType === Node.TEXT_NODE){
-        /* preserve leading/trailing spaces once, collapse internals */      // TEI whitespace rules :contentReference[oaicite:2]{index=2}
+        /* preserve significant spaces, ignore purely formatting whitespace */
         let text = ch.nodeValue;
+        if(text.trim() === '') return;
         const startSpace = /^\s/.test(text);
         const endSpace   = /\s$/.test(text);
         text = text.trim().replace(/\s+/g,' ');


### PR DESCRIPTION
## Summary
- trim whitespace-only DOM text nodes when converting TEI XML to HTML so that indenting in the XML doesn't create huge gaps

## Testing
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_683ae442e6008331af69e4e037633dba