### PR TITLE
Enhance reader interaction

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -76,3 +76,38 @@ h2{font-size:clamp(1.5rem,1vw + 1rem,2.25rem);font-weight:700;}
 @media(min-width:80rem){
   main{padding:3rem;}
 }
+
+/* bottom sheet play picker */
+#playSheet{
+  position:fixed;
+  left:0;right:0;bottom:0;
+  background:var(--bg);
+  color:var(--fg);
+  border-top-left-radius:var(--radius);
+  border-top-right-radius:var(--radius);
+  box-shadow:0 -2px 10px rgba(0,0,0,0.5);
+  transform:translateY(100%);
+  transition:transform .3s;
+  padding:var(--space);
+  max-height:60vh;
+  overflow-y:auto;
+}
+#playSheet.open{transform:none;}
+#playSheet ul{list-style:none;margin:0;padding:0;}
+#playSheet li{padding:0.5rem 0;border-bottom:1px solid var(--accent-2);cursor:pointer;}
+
+/* tooltip for dictionary definitions */
+.tooltip{
+  position:fixed;
+  max-width:60ch;
+  background:var(--bg);
+  color:var(--fg);
+  padding:0.5rem;
+  border-radius:var(--radius);
+  box-shadow:0 2px 6px rgba(0,0,0,0.3);
+  z-index:1000;
+}
+
+.lookup{cursor:help;border-bottom:1px dotted var(--accent-2);}
+
+.act-title,.scene-title{font-family:'Playfair Display',serif;}

--- a/reader.html
+++ b/reader.html
@@ -24,6 +24,7 @@
   <div id="viewer" aria-live="polite">Loading…</div>
   <button id="nextBtn" style="display:none">Next Scene →</button>
   <div id="announce" class="visually-hidden" aria-live="polite"></div>
+  <div id="playSheet"><ul></ul></div>
 </main>
 <svg style="display:none" aria-hidden="true">
   <symbol id="copy" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- add a bottom‑sheet play picker
- update copy button markup and dictionary lookup
- show progress indicator correctly
- style tooltip and sheet

## Testing
- `node --check js/reader.js`

------
https://chatgpt.com/codex/tasks/task_e_683b1c25cc8083319a12da4eafe8134b