### PR TITLE
Improve mobile spacing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -107,6 +107,7 @@ h2{font-size:clamp(1.5rem,1vw + 1rem,2.25rem);font-weight:700;}
 .ghost.revealed{opacity:0.2;}
 .visually-hidden{position:absolute;left:-9999px}
 .word{cursor:help;}
+main{padding:var(--space);}
 @media(min-width:48rem){
   main{padding:2rem;}
 }


### PR DESCRIPTION
## Summary
- add padding for `main` so text doesn't hug the edge on mobile screens

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683b24dc572c833193ac91a6d05ce78d