### PR TITLE
Fix missing spaces in Act 1 scene openers

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -216,19 +216,11 @@
         switch(ch.nodeName){
           case "w":
             out += `<span class="lookup" data-word="${ch.textContent}" data-line-id="${currentLineId}">${ch.textContent}</span>`;
-
-            if(!hasFollowingSpace(ch) && nextTokenIsWord(ch)) out += ' ';
-            break;
-          case "pc":
-            out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
-            /* never append implicit space after punctuation */
-
             if(!hasFollowingSpace(ch)) out += ' ';
             break;
           case "pc":
             out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
             if(!hasFollowingSpace(ch)) out += ' ';
-
             break;
           case "c":    out += " ";                          break;
           case "lb": {


### PR DESCRIPTION
## Summary
- fix spacing logic for `w` and `pc` elements so leading scene lines don't run together

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_683b6b7660f88331bf1427eb0cd10f52