### PR TITLE
Fix missing spaces in tokenised opening lines

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -120,6 +120,14 @@
     return false;
   }
 
+  function needsSpace(node){
+    let nxt = node.nextSibling;
+    while(nxt && nxt.nodeType === Node.TEXT_NODE && !/\S/.test(nxt.nodeValue)){
+      nxt = nxt.nextSibling;
+    }
+    return nxt && nxt.nodeName === 'w';
+  }
+
   function getLineText(el){
     return Array.from(el.childNodes).map(nodeText).join('').trim();
   }
@@ -216,19 +224,11 @@
         switch(ch.nodeName){
           case "w":
             out += `<span class="lookup" data-word="${ch.textContent}" data-line-id="${currentLineId}">${ch.textContent}</span>`;
-
-            if(!hasFollowingSpace(ch) && nextTokenIsWord(ch)) out += ' ';
-            break;
-          case "pc":
-            out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
-            /* never append implicit space after punctuation */
-
-            if(!hasFollowingSpace(ch)) out += ' ';
+            if(needsSpace(ch)) out += ' ';
             break;
           case "pc":
             out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
             if(!hasFollowingSpace(ch)) out += ' ';
-
             break;
           case "c":    out += " ";                          break;
           case "lb": {


### PR DESCRIPTION
## Summary
- add `needsSpace` helper to detect missing spaces between `<w>` tokens
- use `needsSpace` when rendering words

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_683b6b7660f88331bf1427eb0cd10f52