### PR TITLE
Restore previous word spacing logic

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -108,12 +108,24 @@
     }
   }
 
-  function nextTagName(node){
+  function hasFollowingSpace(node){
+    let next = node.nextSibling;
+    while(next){
+      if(next.nodeType===Node.TEXT_NODE && next.nodeValue.trim()===''){
+        next = next.nextSibling;
+        continue;
+      }
+      return next && (next.nodeName==='c' || next.nodeName==='lb' || next.nodeName==='l');
+    }
+    return false;
+  }
+
+  function needsSpace(node){
     let nxt = node.nextSibling;
     while(nxt && nxt.nodeType === Node.TEXT_NODE && !/\S/.test(nxt.nodeValue)){
       nxt = nxt.nextSibling;
     }
-    return nxt ? nxt.nodeName : '';
+    return nxt && nxt.nodeName === 'w';
   }
 
   function getLineText(el){
@@ -210,18 +222,15 @@
         if(endSpace)   out += ' ';
       }else{
         switch(ch.nodeName){
-          case "w": {
+          case "w":
             out += `<span class="lookup" data-word="${ch.textContent}" data-line-id="${currentLineId}">${ch.textContent}</span>`;
-            const next = nextTagName(ch);
-            if(next && !['pc','c','lb','l'].includes(next)) out += ' ';
+            if(needsSpace(ch)) out += ' ';
+            if(!hasFollowingSpace(ch)) out += ' ';
             break;
-          }
-          case "pc": {
+          case "pc":
             out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
-            const next = nextTagName(ch);
-            if(next && !['pc','c','lb','l'].includes(next)) out += ' ';
+            if(!hasFollowingSpace(ch)) out += ' ';
             break;
-          }
           case "c":    out += " ";                          break;
           case "lb": {
             const id = ch.getAttribute('xml:id') || '';


### PR DESCRIPTION
## Summary
- revert query selector formatting changes
- restore `hasFollowingSpace` and `needsSpace` functions
- revert `teiToHtml` spacing checks to previous behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683b88b225008331a1e9ed4fcdc8af36