### PR TITLE
Refactor reader formatting

### DIFF
--- a/js/formatting.js
+++ b/js/formatting.js
@@ -1,0 +1,143 @@
+// Formatting utilities for TEI Simple XML
+// Extracted from reader.js so that formatting logic is isolated.
+
+// Return text content for a TEI node, respecting spaces
+export function nodeText(n) {
+  if (n.nodeType === Node.TEXT_NODE) return n.nodeValue;
+  switch (n.nodeName) {
+    case 'w':
+    case 'pc':
+      return n.textContent;
+    case 'c':
+      return ' ';
+    default:
+      return Array.from(n.childNodes).map(nodeText).join('');
+  }
+}
+
+function hasFollowingSpace(node) {
+  let next = node.nextSibling;
+  while (next) {
+    if (next.nodeType === Node.TEXT_NODE && next.nodeValue.trim() === '') {
+      next = next.nextSibling;
+      continue;
+    }
+    return next && (next.nodeName === 'c' || next.nodeName === 'lb' || next.nodeName === 'l');
+  }
+  return false;
+}
+
+function needsSpace(node) {
+  let nxt = node.nextSibling;
+  while (nxt && nxt.nodeType === Node.TEXT_NODE && !/\S/.test(nxt.nodeValue)) {
+    nxt = nxt.nextSibling;
+  }
+  return nxt && nxt.nodeName === 'w';
+}
+
+// Get a line of text from a TEI element
+export function getLineText(el) {
+  return Array.from(el.childNodes).map(nodeText).join('').trim();
+}
+
+// Track the current line id while building HTML
+let currentLineId = '';
+
+// Convert a TEI node to the HTML used by the reader
+export function teiToHtml(node) {
+  if (!node) return '';
+  let out = '';
+  node.childNodes.forEach(ch => {
+    if (ch.nodeType === Node.TEXT_NODE) {
+      // preserve significant spaces, ignore purely formatting whitespace
+      let text = ch.nodeValue;
+      if (text.trim() === '') return;
+      const startSpace = /^\s/.test(text);
+      const endSpace = /\s$/.test(text);
+      text = text.trim().replace(/\s+/g, ' ');
+      if (startSpace) out += ' ';
+      out += text;
+      if (endSpace) out += ' ';
+    } else {
+      switch (ch.nodeName) {
+        case 'w':
+          out += `<span class="lookup" data-word="${ch.textContent}" data-line-id="${currentLineId}">${ch.textContent}</span>`;
+          if (needsSpace(ch)) out += ' ';
+          if (!hasFollowingSpace(ch)) out += ' ';
+          break;
+        case 'pc':
+          out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
+          if (!hasFollowingSpace(ch)) out += ' ';
+          break;
+        case 'c':
+          out += ' ';
+          break;
+        case 'lb': {
+          const id = ch.getAttribute('xml:id') || '';
+          const n = ch.getAttribute('n') || '';
+          out += `<br id="${id}" data-line="${n}">`;
+          currentLineId = id;
+          break;
+        }
+        case 'l': {
+          const prev = currentLineId;
+          const id = ch.getAttribute('xml:id') || '';
+          const n = ch.getAttribute('n') || '';
+          currentLineId = id;
+          ch.childNodes.forEach(c => {
+            out += teiToHtml(c);
+          });
+          out += `<br id="${id}" data-line="${n}">`;
+          currentLineId = prev;
+          break;
+        }
+        case 'p':
+          out += teiToHtml(ch) + '<br><br>';
+          break;
+        case 'speaker': {
+          out += '<strong>' + teiToHtml(ch) + '</strong>';
+          let next = ch.nextElementSibling;
+          while (next && next.nodeType !== 1) {
+            next = next.nextSibling;
+          }
+          if (next && next.nodeName === 'stage') {
+            out += ' ';
+          } else {
+            out += '<br>';
+          }
+          break;
+        }
+        case 'stage':
+          out += '<em>' + teiToHtml(ch) + '</em><br>';
+          break;
+        case 'castList':
+          out += '<h2 class="act-title">Dramatis Personae</h2><ul>' + teiToHtml(ch) + '</ul><br>';
+          break;
+        case 'castItem': {
+          const name = ch.querySelector('role');
+          const desc = ch.querySelector('roleDesc');
+          const text = (name ? teiToHtml(name).trim() : '') + (desc ? ' — ' + teiToHtml(desc).trim() : '');
+          if (text.trim()) out += '<li>' + text + '</li>';
+          break;
+        }
+        case 'head':
+          if (ch.parentNode && ch.parentNode.nodeName === 'castGroup') {
+            out += '<li><strong>' + teiToHtml(ch) + '</strong></li>';
+          } else {
+            out += '<h3 class="scene-title">' + teiToHtml(ch) + '</h3>';
+          }
+          break;
+        case 'sp':
+          out += '<p class="speech"><span class="speech-text">' + teiToHtml(ch) + '</span>' +
+            '<button class="copy-btn" aria-label="Copy">' +
+            '<img class="icon copy" src="assets/copyIcon.png" alt="">' +
+            '<img class="icon check" src="assets/tick.png" alt="">' +
+            '</button></p>';
+          break;
+        default:
+          out += teiToHtml(ch);
+      }
+    }
+  });
+  return out;
+}


### PR DESCRIPTION
## Summary
- add `formatting.js` module with TEI-to-HTML helpers
- import formatting helpers in `reader.js`
- remove formatting code from `reader.js`

## Testing
- `node -e "import('./js/reader.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_683b8dc77de08331ba58102044bd5e1c