### PR TITLE
Fix spacing between words in reader

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -236,6 +236,7 @@ header.compact h1{font-size:1.25rem;transition:.3s;}
   box-shadow:0 2px 6px rgba(0,0,0,.3);z-index:1000;
 }
 .lookup{cursor:help;}
+.lookup::after{content:" ";}
 
 /* ---------- act / scene titles ---------- */
 .act-title,.scene-title{font-family:'Playfair Display',serif;}

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -15,25 +15,6 @@ export function nodeText(n) {
   }
 }
 
-function hasFollowingSpace(node) {
-  let next = node.nextSibling;
-  while (next) {
-    if (next.nodeType === Node.TEXT_NODE && next.nodeValue.trim() === '') {
-      next = next.nextSibling;
-      continue;
-    }
-    return next && (next.nodeName === 'c' || next.nodeName === 'lb' || next.nodeName === 'l');
-  }
-  return false;
-}
-
-function needsSpace(node) {
-  let nxt = node.nextSibling;
-  while (nxt && nxt.nodeType === Node.TEXT_NODE && !/\S/.test(nxt.nodeValue)) {
-    nxt = nxt.nextSibling;
-  }
-  return nxt && nxt.nodeName === 'w';
-}
 
 // Get a line of text from a TEI element
 export function getLineText(el) {
@@ -62,12 +43,21 @@ export function teiToHtml(node) {
       switch (ch.nodeName) {
         case 'w':
           out += `<span class="lookup" data-word="${ch.textContent}" data-line-id="${currentLineId}">${ch.textContent}</span>`;
-          if (needsSpace(ch)) out += ' ';
-          if (!hasFollowingSpace(ch)) out += ' ';
+          {
+            const next = ch.nextSibling;
+            const mustBreak = next && /^(lb|l)$/.test(next.nodeName);
+            const explicitSpace = next && next.nodeName === 'c';
+            if (!mustBreak && !explicitSpace) out += ' ';
+          }
           break;
         case 'pc':
           out += `<span data-line-id="${currentLineId}">${ch.textContent}</span>`;
-          if (!hasFollowingSpace(ch)) out += ' ';
+          {
+            const next = ch.nextSibling;
+            const mustBreak = next && /^(lb|l)$/.test(next.nodeName);
+            const explicitSpace = next && next.nodeName === 'c';
+            if (!mustBreak && !explicitSpace) out += ' ';
+          }
           break;
         case 'c':
           out += ' ';


### PR DESCRIPTION
## Summary
- ensure each word span outputs a trailing space via JS
- append space after punctuation spans
- remove unused spacing helpers
- add CSS rule to keep spaces from collapsing

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683c0f897fc88331bfcacb4672073d45