### PR TITLE
Fix missing play list and page title

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -61,10 +61,6 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
   const sceneCtrl   = d? d.getElementById('sceneCtrl') : null;
   const contentsBtn = d? d.querySelector('.contents-btn') : {style:{}};
   if(contentsBtn.style) contentsBtn.style.display = 'none';
-
-const header      = d? d.querySelector('header') : null;
-const playTitle   = d? d.getElementById('playTitle') : {textContent:''};
-
   const header      = d? d.querySelector('header') : null;
   const playTitleEl = d? d.getElementById('playTitle') : {textContent:''};
 
@@ -342,23 +338,7 @@ const playTitle   = d? d.getElementById('playTitle') : {textContent:''};
   }
 
   /* --------------- main load ------------------ */
-
-async function loadPlay(file){
-    const title = file.replace(/_TEIsimple_FolgerShakespeare\.xml$/, '')
-                      .replace(/-/g, ' ')
-                      .replace(/\b\w/g, c => c.toUpperCase());
-    playTitle.textContent = title;
-
   async function loadPlay(file){
-
-    const title = file.replace(/_TEIsimple_FolgerShakespeare\.xml$/, '')
-                      .replace(/-/g, ' ')
-                      .replace(/\b\w/g, c => c.toUpperCase());
-    playTitleEl.textContent = title;
-    if(typeof document !== 'undefined'){
-      document.title = `Shakespeare Reader \u2013 ${title}`;
-    }
-
     const title = file.replace(/_TEIsimple_FolgerShakespeare\.xml$/,"")
                       .replace(/-/g, " ")
                       .replace(/\b\w/g, c => c.toUpperCase());
@@ -366,8 +346,6 @@ async function loadPlay(file){
     if(typeof document !== 'undefined'){
       document.title = `Shakespeare Reader – ${title}`;
     }
-
-
     contentsBtn.style.display = 'none';
     viewer.textContent = 'Loading… 0 %';
     try{

--- a/reader.html
+++ b/reader.html
@@ -11,12 +11,8 @@
 <body>
 <header class="large">
   <a href="index.html" class="home-btn" aria-label="Back">&#x2190;</a>
-
-  <h1 class="brand-text" id="playTitle">Choose a play</h1>
-
   <h1 class="brand-text">Shakespeare Reader</h1>
   <h2 id="playTitle" class="play-title brand-text"></h2>
-
 </header>
 <main>
   <div id="cast"></div>


### PR DESCRIPTION
## Summary
- restore `reader.html` header markup
- revert `js/reader.js` to show play list and correctly set the play title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cc465f12083318baa58be06c01f8e