### PR TITLE
Restore simple line number display

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -251,3 +251,12 @@ header.compact .play-title{font-size:1rem;transition:.3s;}
   animation:fadeFlash 3s forwards;
 }
 @keyframes fadeFlash{0%,60%{opacity:1}100%{opacity:0}}
+
+.line-num{
+  display:inline-block;
+  width:4ch;
+  margin-right:0.25rem;
+  color:var(--accent-2);
+  font-size:0.8em;
+  user-select:none;
+}

--- a/js/reader.js
+++ b/js/reader.js
@@ -250,6 +250,7 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
     }
 
     viewer.innerHTML = html;
+    insertLineNumbers();
     castDiv.innerHTML = "";
 
     populateLines(currentScene);
@@ -519,6 +520,24 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
       });
       setTimeout(()=>activeHighlight.forEach(el=>el.classList.remove('line-hit')),3000);
     }
+  }
+
+  function insertLineNumbers(){
+    if(!viewer) return;
+    viewer.querySelectorAll('.line-num').forEach(n=>n.remove());
+    const brs = viewer.querySelectorAll('br[data-line]');
+    brs.forEach(br=>{
+      const n = br.getAttribute('data-line');
+      if(!n) return;
+      const num = parseInt(n.split('.').pop(),10);
+      if(num % 5 === 0){
+        const span=document.createElement('span');
+        span.className='line-num';
+        span.textContent=n;
+        span.dataset.lineId=br.id;
+        br.after(span,' ');
+      }
+    });
   }
 
 


### PR DESCRIPTION
## Summary
- revert line number layout to simple spans
- clean up JS to match previous implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f57a0e44883318804afbd280359f8