### PR TITLE
Improve text size slider UX

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -497,6 +497,7 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
 
   if(sizeRange){
     sizeRange.addEventListener('input',updateFontSize);
+    sizeRange.addEventListener('change',()=>closeSheet(sizeSheet));
     updateFontSize();
   }
 


### PR DESCRIPTION
## Summary
- add a `change` handler for the text size range input to automatically close the size slider after adjusting the font size

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847466a28b88331b0cd565adc5561ee