### PR TITLE
Fix verse line number layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -291,3 +291,17 @@ header.compact .play-title{font-size:1rem;transition:.3s;}
   user-select:none;
   text-align:right;
 }
+
+.verse{
+  position:relative;
+  padding-right:4rem;
+  margin:0;
+}
+.ln{
+  position:absolute;
+  right:0;
+  top:0;
+  font-size:.75em;
+  line-height:1;
+  pointer-events:none;
+}

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -56,7 +56,11 @@ export function teiToHtml(node) {
         case 'l': {
           const id = ch.getAttribute('xml:id') || '';
           const n  = ch.getAttribute('n') || '';
-          out += teiToHtml(ch) + `<br id="${id}" data-line="${n}">`;
+          let inner = '';
+          ch.childNodes.forEach(child => { inner += teiToHtml(child); });
+          out += `<p class="verse" id="${id}" data-line="${n}" data-line-id="${id}">` +
+                 inner +
+                 ` <span class="ln" aria-hidden="true">${n}</span></p>`;
           break;
         }
         case 'p':


### PR DESCRIPTION
## Summary
- convert `<l>` elements into dedicated verse blocks with inline numbers
- keep numbers aligned using new verse styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d743e4a0c833183cea766e60ce465