### PR TITLE
Add word info panel and clean parser

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -276,6 +276,15 @@ header.compact .play-title{font-size:1rem;transition:.3s;}
 }
 @keyframes fadeFlash{0%,60%{opacity:1}100%{opacity:0}}
 
+.verse, .prose{margin:0 0 .5em 0;line-height:1.4;}
+#panel{
+  position:fixed;bottom:1rem;left:1rem;right:1rem;
+  max-height:45vh;overflow:auto;
+  background:#111;color:#eee;
+  border:1px solid #444;border-radius:6px;
+  padding:1rem;z-index:1000;display:none;
+}
+
 
 
 

--- a/reader.html
+++ b/reader.html
@@ -52,6 +52,7 @@
   <button class="size-btn" aria-label="Text size">Aa</button>
 
   <button class="contents-btn" aria-label="Contents">Contents</button>
+  <div id="panel"></div>
 </main>
 
 <!-- copy / check icons -->


### PR DESCRIPTION
## Summary
- rework TEI formatting to emit proper verse and prose lines
- show definitions in a slide‑up panel when tapping a word
- include panel element and minimal CSS

## Testing
- `npm install xmldom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d8146c5148331814308dbe6d7d49e