### PR TITLE
Fix extra spaces in text rendering

### DIFF
--- a/js/formatting.js
+++ b/js/formatting.js
@@ -27,13 +27,11 @@ function emitTokens(parent){
     if(node.nodeName === 'w'){
       const ref = node.getAttribute('n') || '';
       html.push(`<span class="word" data-ref="${ref}">${node.textContent}</span>`);
-      html.push(' ');
     }else if(node.nodeName === 'pc'){
       if(html[html.length-1] === ' ') html.pop();
       html.push(node.textContent);
-      html.push(' ');
     }else if(node.nodeName === 'c'){
-      html.push(' ');
+      if(html[html.length-1] !== ' ') html.push(' ');
     }else{
       html.push(teiToHtml(node));
     }


### PR DESCRIPTION
## Summary
- preserve spaces from TEI XML correctly by letting `<c>` tokens supply whitespace
- remove unconditional space after word tokens in `emitTokens`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d832bec2483319e9bf42efa27da30