### PR TITLE
Preserve scroll when adjusting text size

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -24,7 +24,12 @@ body{
   background:var(--bg);
   color:var(--fg);
 }
-body.noscroll{height:100vh;overflow:hidden;}
+body.noscroll{
+  position:fixed;
+  width:100%;
+  height:100vh;
+  overflow:hidden;
+}
 h1,h2,h3{
   font-family:'Inter',sans-serif;
   margin:0 0 var(--space);

--- a/js/reader.js
+++ b/js/reader.js
@@ -74,6 +74,9 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
   let lines = [];
   const lineNodes = new Map();
 
+  /* scroll position for returning after closing a sheet */
+  let savedScroll = 0;
+
   /* copy-to-clipboard buttons */
   const announce = d? d.getElementById('announce') : {textContent:''};
 
@@ -544,6 +547,8 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
   }
 
   function openSheet(sheet){
+    savedScroll = window.scrollY || window.pageYOffset || 0;
+    document.body.style.top = `-${savedScroll}px`;
     sheet.classList.add('open');
     contentsBtn.style.display = 'none';
 
@@ -562,6 +567,8 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
     if(searchBtn) searchBtn.style.display = '';
     if(sizeBtn) sizeBtn.style.display = '';
     document.body.classList.remove('noscroll');
+    document.body.style.top = '';
+    window.scrollTo(0, savedScroll);
   }
 
   function renderSearchResults(items){


### PR DESCRIPTION
## Summary
- keep track of scroll position when opening a settings sheet
- apply saved scroll after closing
- adjust CSS for `body.noscroll` to use fixed positioning

## Testing
- `node --check js/reader.js`

------
https://chatgpt.com/codex/tasks/task_e_684d8591a1cc8331b4c069c5278dc77f