### PR TITLE
Add copy button for speeches

### DIFF
--- a/js/formatting.js
+++ b/js/formatting.js
@@ -133,7 +133,7 @@ export function teiToHtml(node) {
             else speech += teiToHtml(child);
           });
           out += '<p class="speech"><span class="speech-text">' + speech + '</span>' +
-            '<button class="copy-btn" aria-label="Copy">' +
+            '<button class="copy-btn" type="button" aria-label="Copy this speech" title="Copy">' +
             '<img class="icon copy" src="assets/copyIcon.png" alt="">' +
             '<img class="icon check" src="assets/tick.png" alt="">' +
             '</button></p>';


### PR DESCRIPTION
## Summary
- make the copy icon a proper button with accessible text
- the reader already includes logic to copy any speech to the clipboard when the new button is clicked

## Testing
- `npx --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_684d87ea46f08331be54596f3219800c