### PR TITLE
Fix dictionary popups for non-line words

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -342,6 +342,7 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
     document.addEventListener('click',e=>{
       const w=e.target.closest('.word');
       if(!w) return;
+      if(!/^\d+\.\d+\.\d+$/.test(w.dataset.ref)) return;
       const [act,scene,line]=w.dataset.ref.split('.');
       const word=w.textContent;
       panel.innerHTML=`<strong>${word}</strong><br>Act ${act}, Scene ${scene}, Line ${line}<br><em>Loading…</em>`;


### PR DESCRIPTION
## Summary
- ignore clicks on tokens that lack numeric line references

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d8e35545c8331a694fc7abd007729