### PR TITLE
Fix copy button icon overlay

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -95,6 +95,11 @@ h2{font-size:clamp(1.5rem,1vw + 1rem,2.25rem);font-weight:700;}
   border:none;background:none;padding:0;
   cursor:pointer;
 }
+.copy-btn .icon{
+  position:absolute;
+  top:0;
+  left:0;
+}
 
 /* ---------- navigation ---------- */
 .home-btn{


### PR DESCRIPTION
## Summary
- overlay copy icon images so tick icon can replace it on click

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d8f0e924c833198be5d1d61c5177e