### PR TITLE
Remove speech copy feature

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -88,18 +88,6 @@ h2{font-size:clamp(1.5rem,1vw + 1rem,2.25rem);font-weight:700;}
 #viewer{white-space:pre-wrap;font-size:var(--play-font-size,1rem);}
 #cast{font-size:var(--play-font-size,1rem);}
 .speech{position:relative;margin-bottom:var(--space);}
-.copy-btn{
-  margin-left:0.5rem;
-  position:relative;
-  width:2rem;height:2rem;
-  border:none;background:none;padding:0;
-  cursor:pointer;
-}
-.copy-btn .icon{
-  position:absolute;
-  top:0;
-  left:0;
-}
 
 /* ---------- navigation ---------- */
 .home-btn{
@@ -115,9 +103,6 @@ header.compact .home-btn .icon{width:1rem;height:1rem;}
 
 /* ---------- icons ---------- */
 .icon{width:1rem;height:1rem;transition:opacity .2s;vertical-align:middle;}
-.check{opacity:0;}
-.copied .copy{opacity:0;}
-.copied .check{opacity:1;}
 
 /* ---------- animation helpers ---------- */
 .fade-in{opacity:0;transform:translateY(1rem);transition:opacity .5s,transform .5s;}

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -132,11 +132,7 @@ export function teiToHtml(node) {
             else if(child.nodeName === 'stage') speech += '<em>' + teiToHtml(child) + '</em><br>';
             else speech += teiToHtml(child);
           });
-          out += '<p class="speech"><span class="speech-text">' + speech + '</span>' +
-            '<button class="copy-btn" type="button" aria-label="Copy this speech" title="Copy">' +
-            '<img class="icon copy" src="assets/copyIcon.png" alt="">' +
-            '<img class="icon check" src="assets/tick.png" alt="">' +
-            '</button></p>';
+          out += '<p class="speech"><span class="speech-text">' + speech + '</span></p>';
           break;
         }
         default:

--- a/js/reader.js
+++ b/js/reader.js
@@ -82,44 +82,6 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
   /* global overlay element for closing sheets */
   let sheetOverlay = null;
 
-  /* copy-to-clipboard buttons */
-  const announce = d? d.getElementById('announce') : {textContent:''};
-
-  function fallbackCopy(text){
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.setAttribute('readonly', '');
-    ta.style.position = 'fixed';
-    ta.style.left = '-9999px';
-    document.body.appendChild(ta);
-    ta.select();
-    try{ document.execCommand('copy'); }catch(e){}
-    document.body.removeChild(ta);
-    return Promise.resolve();
-  }
-
-  function copyText(text){
-    if(navigator.clipboard && navigator.clipboard.writeText){
-      return navigator.clipboard.writeText(text).catch(()=>fallbackCopy(text));
-    }
-    return fallbackCopy(text);
-  }
-
-  function handleCopy(e){
-    const btn = e.target.closest('.copy-btn');
-    if(!btn) return;
-    const speechEl = btn.closest('.speech').querySelector('.speech-text');
-    const speech = speechEl ? speechEl.textContent : '';
-    copyText(speech).then(() => {
-      btn.classList.add('copied');
-      announce.textContent = 'Copied!';
-      setTimeout(() => btn.classList.remove('copied'), 1000);
-    });
-  }
-
-  if(viewer && viewer.addEventListener){
-    viewer.addEventListener('click', handleCopy);
-  }
 
   const parser      = (typeof DOMParser==='undefined') ? {parseFromString:()=>null} : new DOMParser();
   let   currentDoc  = null;

--- a/reader.html
+++ b/reader.html
@@ -21,7 +21,6 @@
   <div id="cast"></div>
   <div id="viewer" aria-live="polite"></div>
   <button id="nextBtn" style="display:none">Next Scene →</button>
-  <div id="announce" class="visually-hidden" aria-live="polite"></div>
   <button id="resumeBtn" class="resume-btn" style="display:none">Resume Reading</button>
 
   <!-- merged bottom-sheet play menu -->
@@ -55,15 +54,6 @@
   <div id="panel"></div>
 </main>
 
-<!-- copy / check icons -->
-<svg style="display:none" aria-hidden="true">
-  <symbol id="copy" viewBox="0 0 24 24">
-    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 18H8V7h11v16z"/>
-  </symbol>
-  <symbol id="check" viewBox="0 0 24 24">
-    <path d="M9 16.2l-3.5-3.5-1.4 1.4L9 19l12-12-1.4-1.4z"/>
-  </symbol>
-</svg>
 
 <script type="module" src="js/reader.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- strip out the copy-to-clipboard feature from reader markup and scripts
- clean up styles related to copy buttons
- drop unused icons in the reader page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d903695f48331b8e4b2931584a9b1