### PR TITLE
Improve search results and remove close icon

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -169,11 +169,6 @@ main{padding:var(--space);}
   background: transparent;
   z-index:4;
 }
-#searchSheet .sheet-close{
-  position:absolute;top:0.25rem;right:0.5rem;
-  background:none;border:none;font-size:1.5rem;
-  color:var(--fg);cursor:pointer;
-}
 #playSheet ul{list-style:none;margin:0;padding:0;}
 #playSheet input[type=search]{
   width:100%;margin-bottom:.5rem;

--- a/js/reader.js
+++ b/js/reader.js
@@ -49,7 +49,6 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
   const searchSheet = d? d.getElementById('searchSheet') : null;
   const searchInput = searchSheet ? searchSheet.querySelector('input[type=search]') : null;
   const searchList  = searchSheet ? searchSheet.querySelector('ul') : null;
-  const searchClose = searchSheet ? searchSheet.querySelector('.sheet-close') : null;
   const searchBtn   = d? d.querySelector('.search-btn') : {style:{display:'none'}};
   const sizeBtn     = d? d.querySelector('.size-btn') : {style:{display:'none'}};
   const viewer      = d? d.getElementById("viewer")  : {innerHTML:'',textContent:''};
@@ -435,18 +434,15 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
     });
   }
 
-  if(searchClose){
-    searchClose.addEventListener('click',()=>closeSheet(searchSheet));
-  }
 
   if(searchInput){
     let timer=null;
     searchInput.addEventListener('input',()=>{
       clearTimeout(timer);
       timer=setTimeout(()=>{
-        const term=searchInput.value.toLowerCase();
-        const hits=term?lines.filter(l=>l.text.toLowerCase().includes(term)):[];
-        renderSearchResults(hits);
+        const term = searchInput.value.toLowerCase();
+        const hits = term ? lines.filter(l => l.text.toLowerCase().includes(term)) : [];
+        renderSearchResults(hits, term);
       },150);
     });
   }
@@ -545,14 +541,17 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
     }
   }
 
-  function renderSearchResults(items){
+  function renderSearchResults(items, term){
     if(!searchList) return;
-    searchList.innerHTML='';
-    items.forEach(l=>{
-      const li=document.createElement('li');
-      li.dataset.id=l.id;
-      const preview=l.text.slice(0,60);
-      li.innerHTML=`<div><strong>${l.ref}</strong></div><div>${preview}</div>`;
+    searchList.innerHTML = '';
+    const esc = term ? term.replace(/[.*+?^${}()|[\]\\]/g,'\\$&') : '';
+    const regex = esc ? new RegExp(`(${esc})`, 'ig') : null;
+    items.forEach(l => {
+      const li = document.createElement('li');
+      li.dataset.id = l.id;
+      let text = l.text;
+      if(regex) text = l.text.replace(regex, '<mark>$1</mark>');
+      li.innerHTML = `<div><strong>${l.ref}</strong></div><div>${text}</div>`;
       searchList.appendChild(li);
     });
   }

--- a/reader.html
+++ b/reader.html
@@ -36,7 +36,6 @@
   </div>
 
   <div id="searchSheet" class="sheet" role="dialog" aria-modal="true" aria-label="Search lines">
-    <button class="sheet-close" aria-label="Close">&#x2715;</button>
     <input type="search" placeholder="Search…">
     <ul></ul>
   </div>


### PR DESCRIPTION
## Summary
- remove redundant close icon from search sheet
- display whole lines in search results and highlight matches

## Testing
- `node -e "require('./js/reader.js');"`
- `node -c js/reader.js`
- `npx eslint js/reader.js` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d92ff2d148331a67db2555625b996