### PR TITLE
Fix search UI spacing and button color

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -176,6 +176,10 @@ main{padding:var(--space);}
   border:1px solid var(--accent-2);
   background:var(--bg);color:var(--fg);
   font-size:16px;
+  accent-color:#fff;
+}
+#playSheet input[type=search]::-webkit-search-cancel-button{
+  filter:invert(1);
 }
 #searchSheet ul{list-style:none;margin:0;padding:0;}
 #searchSheet input[type=search]{
@@ -184,10 +188,16 @@ main{padding:var(--space);}
   border:1px solid var(--accent-2);
   background:var(--bg);color:var(--fg);
   font-size:16px;
+  /* make the built-in clear button white */
+  accent-color:#fff;
+}
+#searchSheet input[type=search]::-webkit-search-cancel-button{
+  filter:invert(1);
 }
 #searchSheet li{
   padding:0.75rem 0;border-bottom:1px solid var(--accent-2);
   cursor:pointer;min-height:48px;display:flex;align-items:center;
+  gap:.5rem;
 }
 #playSheet li{
   padding:0.75rem 0;border-bottom:1px solid var(--accent-2);

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -3,7 +3,9 @@
 
 // Return text content for a TEI node, respecting spaces
 export function nodeText(n) {
-  if (n.nodeType === Node.TEXT_NODE) return n.nodeValue;
+  if (n.nodeType === Node.TEXT_NODE) {
+    return n.nodeValue.trim() === '' ? '' : n.nodeValue;
+  }
   switch (n.nodeName) {
     case 'w':
     case 'pc':


### PR DESCRIPTION
## Summary
- adjust search inputs so clear button is white
- add spacing between search result items
- trim insignificant XML whitespace for cleaner results

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d95b86fb88331b6b2823784be4830