### PR TITLE
Handle lb nodes when extracting text

### DIFF
--- a/js/formatting.js
+++ b/js/formatting.js
@@ -12,6 +12,8 @@ export function nodeText(n) {
       return n.textContent;
     case 'c':
       return ' ';
+    case 'lb':
+      return ' ';
     default:
       return Array.from(n.childNodes).map(nodeText).join('');
   }


### PR DESCRIPTION
## Summary
- treat `<lb>` elements as spaces when building plain text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d97c8871883318779ffbac8f0072c