### PR TITLE
Support prose line breaks

### DIFF
--- a/js/formatting.js
+++ b/js/formatting.js
@@ -52,7 +52,9 @@ function emitVerse(l){
 
 function emitProse(p){
   const inner = emitTokens(p);
-  return `<p class="prose">${inner}</p>`;
+  const id = p.getAttribute && p.getAttribute('xml:id');
+  const attr = id ? ` id="${id}" data-line-id="${id}"` : '';
+  return `<p class="prose"${attr}>${inner}</p>`;
 }
 
 // Convert a TEI node to the HTML used by the reader
@@ -94,6 +96,9 @@ export function teiToHtml(node) {
         case 'p':
           out += emitProse(ch);
           break;
+        case 'ab':
+          out += emitProse(ch);
+          break;
         case 'speaker': {
           out += '<strong>' + teiToHtml(ch) + '</strong>';
           let next = ch.nextElementSibling;
@@ -132,6 +137,7 @@ export function teiToHtml(node) {
           ch.childNodes.forEach(child => {
             if(child.nodeName === 'l') speech += emitVerse(child);
             else if(child.nodeName === 'p') speech += emitProse(child);
+            else if(child.nodeName === 'ab') speech += emitProse(child);
             else if(child.nodeName === 'speaker') speech += '<strong>' + teiToHtml(child) + '</strong><br>';
             else if(child.nodeName === 'stage') speech += '<em>' + teiToHtml(child) + '</em><br>';
             else speech += teiToHtml(child);

--- a/js/reader.js
+++ b/js/reader.js
@@ -102,6 +102,13 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
       lines.push({id, ref, text});
       if(id) lineNodes.set(id, l);
     });
+    xml.querySelectorAll('ab[n]').forEach(ab=>{
+      const id = ab.getAttribute('xml:id') || '';
+      const ref = ab.getAttribute('n') || '';
+      const text = getLineText(ab);
+      lines.push({id, ref, text});
+      if(id) lineNodes.set(id, ab);
+    });
     xml.querySelectorAll('p').forEach(p=>{
       let current = null;
       let buf = '';
@@ -204,7 +211,7 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
     sceneFirstRef = '';
     sceneLastRef  = '';
     if(scene){
-      const els = scene.querySelectorAll('lb[n], l[n]');
+      const els = scene.querySelectorAll('lb[n], l[n], ab[n]');
       if(els.length){
         sceneFirstRef = els[0].getAttribute('n') || '';
         sceneLastRef  = els[els.length-1].getAttribute('n') || '';


### PR DESCRIPTION
## Summary
- add `<ab>` support so prose lines become searchable
- expose `xml:id` on prose paragraphs
- find scene line range using `<ab>` tags as well

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d9c44e9d08331934021e923eaa0ce