### PR TITLE
Implement selective paragraph copy

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -88,6 +88,7 @@ h2{font-size:clamp(1.5rem,1vw + 1rem,2.25rem);font-weight:700;}
 #viewer{white-space:pre-wrap;font-size:var(--play-font-size,1rem);}
 #cast{font-size:var(--play-font-size,1rem);}
 .speech{position:relative;margin-bottom:var(--space);}
+.speech .prose{position:relative;}
 .copy-btn{
   position:absolute;
   right:0;

--- a/js/reader.js
+++ b/js/reader.js
@@ -629,8 +629,8 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
 
   function addCopyButtons(){
     if(!viewer) return;
-    viewer.querySelectorAll('.speech').forEach(sp=>{
-      if(sp.querySelector('.copy-btn')) return;
+    viewer.querySelectorAll('.speech .prose').forEach(p=>{
+      if(p.querySelector('.copy-btn')) return;
       const btn=document.createElement('button');
       btn.type='button';
       btn.className='copy-btn';
@@ -639,13 +639,16 @@ import { teiToHtml, nodeText, getLineText } from './formatting.js';
       img.alt='Copy';
       btn.appendChild(img);
       btn.addEventListener('click',()=>{
-        const text=sp.querySelector('.speech-text')?.innerText||sp.innerText;
-        navigator.clipboard.writeText(text.trim()).then(()=>{
+        const speech=p.closest('.speech');
+        const speaker=speech?.querySelector('strong')?.innerText.trim()||'';
+        const text=p.innerText.trim();
+        const copyText=speaker?`${speaker}\n${text}`:text;
+        navigator.clipboard.writeText(copyText).then(()=>{
           img.src='assets/tick.png';
           setTimeout(()=>{img.src='assets/copyIcon.png';},2000);
         });
       });
-      sp.appendChild(btn);
+      p.appendChild(btn);
     });
   }
 


### PR DESCRIPTION
## Summary
- copy buttons attach to prose paragraphs instead of entire speeches
- copy text now includes speaker name and paragraph
- style prose paragraphs to position copy button correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9e1aebf48331870901d3a60b3c65